### PR TITLE
docs: fix "undefined: mySha256" error

### DIFF
--- a/lab1/实验一.md
+++ b/lab1/实验一.md
@@ -228,7 +228,7 @@ type Blockchain struct {
 
 `go test -v sha256_test.go sha256.go` 验证sha256的结果是否正确
 
-`go test -v merkle_tree_test.go merkle_tree.go` 验证merkle树是否正确
+`go test -v merkle_tree_test.go merkle_tree.go sha256.go` 验证merkle树是否正确
 
 ## 完成部分
 


### PR DESCRIPTION
Hi TA @lluckydog !

In our [lab 1 document](https://github.com/lluckydog/blockchainlab-2022/blob/main/lab1/%E5%AE%9E%E9%AA%8C%E4%B8%80.md), “基本操作” section, when we check if our implementation of `merkle_tree.go` is correct, we run following command: 
```bash
go test -v merkle_tree_test.go merkle_tree.go
```
However, on my computer (WSL2,Ubuntu 20.04 distro), I got following error:
```bash
(base) me@me:~/path-to-lab/lab1/template$ go test -v merkle_tree_test.go merkle_tree.go
# command-line-arguments [command-line-arguments.test]
./merkle_tree.go:52:11: undefined: mySha256
./merkle_tree.go:56:11: undefined: mySha256
FAIL    command-line-arguments [build failed]
FAIL
```
It reads that `mySha256` is not defined. According to [this](https://stackoverflow.com/questions/28153203/undefined-function-declared-in-another-file), maybe we need to add `sha256.go` in parameters?

I tested it on my computer and it works fine:
```bash
(base) me@me:~/path-to-lab/lab1/template$ go test -v merkle_tree_test.go merkle_tree.go sha256.go
=== RUN   TestNewMerkleNode
--- PASS: TestNewMerkleNode (0.00s)
=== RUN   TestNewMerkleTree
--- PASS: TestNewMerkleTree (0.00s)
PASS
ok      command-line-arguments  0.002s
```

Thanks in advance! :)