### PR TITLE
code: targetBits should start from 8 instead of 5

### DIFF
--- a/lab2/template/block.go
+++ b/lab2/template/block.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-var targetBits = uint(5)
+var targetBits = uint(8)
 
 // Block keeps block headers
 type Block struct {


### PR DESCRIPTION
Hi TA @lluckydog !

In our lab 2, the global `targetBits` is set to 5 in `block.go`. in given database `blockchain.db`:

The `targetBits` of sample blocks are 5,6,7. 

![image](https://user-images.githubusercontent.com/52737443/163910147-ed8bcaba-a82e-45d2-87c2-2481d5af978e.png)

However, after the go app exits, the `targetBits` is reset to 5, which means when the students finish the lab and try to add a new block, the `targetBits` starts from 5. So after several creations, the `targetBits` will be like `5,6,7,5,6,7,8,9,...`, which doesn't follow the principle of the difficulty of mining the blocks increases as the number of blocks increases. So can we set it to 8 to follow it?