### PR TITLE
docs: fix docker-compose.yml

### DIFF
--- a/lab3/实验三.md
+++ b/lab3/实验三.md
@@ -152,32 +152,32 @@ networks:
       name: fabric-ca
 services:
   PEERNAME:
-    //PEERNAME 与注册的节点信息保持一致
-    container_name:PEERNAME
-    image:hyperledger/fabric-peer:amd64-2.2.0
+    # PEERNAME 与注册的节点信息保持一致
+    container_name: PEERNAME
+    image: hyperledger/fabric-peer:amd64-2.2.0
     environment:
       - GOPROXY=https://goproxy.cn,direct
       - GO111MODULE=on
-    //CORE_PEER_ID对应注册peer名字
+    # CORE_PEER_ID对应注册peer名字
       - CORE_PEER_ID=org-peer
       - CORE_PEER_ADDRESS=${HOSTNAME}:${PORT}
       - CORE_PEER_LOCALMSPID=org1MSP
-      //对应组织的msp的位置
+      # 对应组织的msp的位置
       - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/org1/peer2/msp
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fabric-ca
       - CORE_PEER_TLS_ENABLED=true
-      //对应组织org1对应的tls签名证书位置
+      # 对应组织org1对应的tls签名证书位置
       - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/org1/peer2/tls-msp/signcerts/cert.pem
-      //对应组织org1的key位置
+      # 对应组织org1的key位置
       - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/org1/peer2/tls-msp/keystore/key.pem
-      //对应组织org1的tls根证书位置
+      # 对应组织org1的tls根证书位置
       - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/org1/peer2/tls-msp/tlscacerts/tls-0-0-0-0-7052.pem
-      //GOSSIP前是否先和orderer节点通信
+      # GOSSIP前是否先和orderer节点通信
       - CORE_PEER_GOSSIP_USELEADERELECTION=false
       - CORE_PEER_GOSSIP_ORGLEADER=true
-      // 组织外部GOSSIP通信的配置
+      # 组织外部GOSSIP通信的配置
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=${HOSTNAME}:${PORT}
       - CORE_PEER_GOSSIP_SKIPHANDSHAKE=true
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric/org1/peer2

--- a/lab3/实验三.md
+++ b/lab3/实验三.md
@@ -153,8 +153,8 @@ networks:
 services:
   PEERNAME:
     //PEERNAME 与注册的节点信息保持一致
-    container_name: PEERNAME
-    image: hyperledger/fabric-peer:amd64-2.2.0
+    container_name:PEERNAME
+    image:hyperledger/fabric-peer:amd64-2.2.0
     environment:
       - GOPROXY=https://goproxy.cn,direct
       - GO111MODULE=on
@@ -188,6 +188,8 @@ services:
     networks:
       - fabric-ca
 ```
+
+docker-compose 的 yml 配置需要严格符合 yaml 语法。 yaml 配置文件写好之后，可以 Google 一下相关的 yaml lint 在线网站，检查一下自己的语法是否符合要求。一个示例网站在 http://www.yamllint.com/
 
 其中CORE_PEER_ADDRESS，CORE_PEER_MSPCONFIGPATH，CORE_PEER_TLS_CERT_FILE，CORE_PEER_TLS_KEY_FILE，CORE_PEER_TLS_ROOTCERT_FILE，CORE_PEER_GOSSIP_EXTERNALENDPOINT需要根据实际情况进行配置，对应的位置为
 

--- a/lab3/实验三.md
+++ b/lab3/实验三.md
@@ -193,7 +193,7 @@ docker-compose 的 yml 配置需要严格符合 yaml 语法。 yaml 配置文件
 
 其中CORE_PEER_ADDRESS，CORE_PEER_MSPCONFIGPATH，CORE_PEER_TLS_CERT_FILE，CORE_PEER_TLS_KEY_FILE，CORE_PEER_TLS_ROOTCERT_FILE，CORE_PEER_GOSSIP_EXTERNALENDPOINT需要根据实际情况进行配置，对应的位置为
 
-    ${HOME}/fabric/org1/peer2/${relative_root} =/etc/hyperledger/org1/peer2/${relative_rrot}
+    ${HOME}/fabric/org1/peer2/${relative_root} =/etc/hyperledger/org1/peer2/${relative_root}
 
 具体可以了解[docker-compose](https://docs.docker.com/compose/gettingstarted/#step-5-edit-the-compose-file-to-add-a-bind-mount)的mount机制
 
@@ -229,15 +229,15 @@ services:
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - FABRIC_LOGGING_SPEC=DEBUG
       - CORE_PEER_ID=cli-org1
-      //peer服务对应的位置
+      # peer服务对应的位置
       - CORE_PEER_ADDRESS=peer2-org1:7051
       - CORE_PEER_LOCALMSPID=org1MSP
       - CORE_PEER_TLS_ENABLED=true
-      //tls根证书
+      # tls根证书
       - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/org1/peer2/tls-msp/tlscacerts/tls-172-16-4-35-7052.pem
-      //tls证书
+      # tls证书
       - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/org1/peer2/tls-msp/signcerts/cert.pem
-      //存储的密钥
+      # 存储的密钥
       - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/org1/peer2/tls-msp/keystore/key.pem
       - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/org1/peer2/msp
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric/org1


### PR DESCRIPTION
* change "//" to "#": using "//" in comments doesn't pass the yaml linting. we can use "#" instead.
* add a yaml lint website
* tested ok on cloud instance